### PR TITLE
add_edge line159 typo

### DIFF
--- a/System/components/attack_graph_parser.py
+++ b/System/components/attack_graph_parser.py
@@ -156,7 +156,7 @@ def add_edge(nodes,
     if node_start_full not in nodes:
         nodes.add(node_start_full)
 
-    if node_end not in nodes:
+    if node_end_full not in nodes:
         nodes.add(node_end_full)
 
     key = node_start_full + "|" + node_end_full 


### PR DESCRIPTION
Hello, I just checked the add_edge function in attack_graph_parser.py and found a possible typo:

line-159        if node_end not in nodes:
line-160            nodes.add(node_end_null)

Should the condition in line 159 be "if node_end_full not in nodes" ?   